### PR TITLE
fix: check error before accessing HTTP response in getToken()

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,6 +104,9 @@ func (f *fetcher) getToken() (string, error) {
 		req.Header.Add("Metadata", "true")
 	}
 	res, err := f.client.Do(req)
+	if err != nil {
+		return "", err
+	}
 	if res.StatusCode != 200 {
 		return "", errors.New(res.Status)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -11,6 +12,12 @@ import (
 )
 
 type dummyClient struct{}
+
+type errorClient struct{}
+
+func (c *errorClient) Do(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("connection timeout")
+}
 
 func (c *dummyClient) Do(req *http.Request) (*http.Response, error) {
 	var body string
@@ -132,4 +139,27 @@ PASSWORD=mysecretvalue1
 	if b.String() != expected {
 		t.Fatalf("got:%s want:%s", b.String(), expected)
 	}
+}
+
+func TestHttpRequestError(t *testing.T) {
+	var b bytes.Buffer
+	template := `PASSWORD={{ kv "https://example.vault.azure.net/secrets/pass" }}
+`
+	client := &errorClient{}
+	r := strings.NewReader(template)
+	defer func() {
+		if r := recover(); r != nil {
+			// Should panic with error message, not nil pointer dereference
+			panicMsg := fmt.Sprintf("%v", r)
+			if strings.Contains(panicMsg, "connection timeout") {
+				return // Expected behavior - error is properly propagated
+			}
+			if strings.Contains(panicMsg, "nil pointer") || strings.Contains(panicMsg, "invalid memory address") {
+				t.Fatalf("nil pointer dereference detected - fix not working: %v", r)
+			}
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	filter(fetcher{client, ""}, r, &b)
+	t.Fatalf("expected panic due to error, but none occurred")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -148,16 +148,16 @@ func TestHttpRequestError(t *testing.T) {
 	client := &errorClient{}
 	r := strings.NewReader(template)
 	defer func() {
-		if r := recover(); r != nil {
+		if panicVal := recover(); panicVal != nil {
 			// Should panic with error message, not nil pointer dereference
-			panicMsg := fmt.Sprintf("%v", r)
+			panicMsg := fmt.Sprintf("%v", panicVal)
 			if strings.Contains(panicMsg, "connection timeout") {
 				return // Expected behavior - error is properly propagated
 			}
 			if strings.Contains(panicMsg, "nil pointer") || strings.Contains(panicMsg, "invalid memory address") {
-				t.Fatalf("nil pointer dereference detected - fix not working: %v", r)
+				t.Fatalf("nil pointer dereference detected - fix not working: %v", panicVal)
 			}
-			t.Fatalf("unexpected panic: %v", r)
+			t.Fatalf("unexpected panic: %v", panicVal)
 		}
 	}()
 	filter(fetcher{client, ""}, r, &b)


### PR DESCRIPTION
## Summary

- Add nil check for `err` before accessing `res.StatusCode` in `getToken()` function
- Prevents nil pointer dereference panic when HTTP request fails (timeout, network error)
- Add `TestHttpRequestError` test to verify proper error handling

Fixes #6

## Test plan

- [x] Existing unit tests pass
- [x] New `TestHttpRequestError` test verifies HTTP errors are properly propagated

🤖 Generated with [Claude Code](https://claude.com/claude-code)