### PR TITLE
リリース時にビルド済みバイナリを添付する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/vaultenv

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,25 @@
+version: 2
+
+project_name: vaultenv
+
+builds:
+  - main: .
+    binary: vaultenv
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,7 @@ archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
-      - README.md
-      - LICENSE
+      - none*
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 # vaultenv 
 Replace Azure Keyvault Secret Identifier written into .env etc.
 ## Installation
+### Prebuilt binary
+Download the linux/amd64 archive from the [Releases](https://github.com/sensyn-robotics/vaultenv/releases) page and extract it.
+```
+tar xzf vaultenv_<version>_linux_amd64.tar.gz
+./vaultenv -version
+```
+### go install
 ```
 go get github.com/sensyn-robotics/vaultenv
 # for go v1.18 and above
@@ -35,4 +42,10 @@ PASSWORD1={{ kv "https://keyvault-name.vault.azure.net/secrets/example-password"
 $ cat .env | vaultenv
 USER1=user1
 PASSWORD1=SecretsFromAzureKeyVault
+```
+## Release
+Push a `v*` tag. The release workflow runs [GoReleaser](https://goreleaser.com/), which creates a GitHub Release and attaches the linux/amd64 archive and `checksums.txt`.
+```
+git tag v1.2.3
+git push origin v1.2.3
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ tar xzf vaultenv_<version>_linux_amd64.tar.gz
 ```
 ### go install
 ```
-go get github.com/sensyn-robotics/vaultenv
-# for go v1.18 and above
 go install github.com/sensyn-robotics/vaultenv@latest
 ```
 ## Usage

--- a/main.go
+++ b/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strings"
 	"text/template"
 	"time"
@@ -27,7 +29,29 @@ type fetcher struct {
 	clients map[string]secretClient
 }
 
+// version is injected at release build time via ldflags (-X main.version=...).
+// It is empty for `go install` and local builds, where versionString() falls
+// back to the module version embedded by the Go toolchain.
+var version = ""
+
+func versionString() string {
+	if version != "" {
+		return version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
+		return bi.Main.Version
+	}
+	return "unknown"
+}
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
+	flag.Parse()
+	if *showVersion {
+		fmt.Println(versionString())
+		return
+	}
+
 	f, err := newFetcher()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
現状 `go install` でのソースインストールしか無く、Go の無い環境や CI で使うにはビルド済みバイナリが欲しいので、リリース時に GitHub Release へバイナリを添付できるようにしました。

## 変更内容

- `v*` タグの push で GoReleaser を走らせる `release` workflow を追加。GitHub Release を作成し、linux/amd64 の tar.gz と `checksums.txt` を添付する
- GoReleaser 設定 `.goreleaser.yaml` を追加 (linux/amd64、tar.gz の中身は `vaultenv` バイナリのみ、checksums 生成)
- `-version` flag を追加。version は ldflags 注入の `main.version` を優先し、無ければ `runtime/debug.ReadBuildInfo()` にフォールバックする (`go install ...@tag` やローカルビルドでも表示できる)
- README に Prebuilt binary のインストール方法と Release 手順を追記
- `.gitignore` を追加 (`dist/`、ビルド成果物の `vaultenv`)

既存の `ci.yml` (全 push で test + build) はそのまま。

## リリース手順

```
git tag v1.2.3
git push origin v1.2.3
```

## 動作確認

- `go test ./...` pass
- `goreleaser release --snapshot --clean` で tar.gz (バイナリのみ) と checksums.txt の生成、バイナリの version 注入を確認
